### PR TITLE
Add semicolons per ES6 standard (Babel requires it)

### DIFF
--- a/NavbarButton.js
+++ b/NavbarButton.js
@@ -29,12 +29,12 @@ export default class NavbarButton extends Component {
     tintColor: PropTypes.string,
     title: PropTypes.string,
     handler: PropTypes.func,
-  }
+  };
 
   static defaultProps = {
     style: {},
     title: '',
     tintColor: '#0076FF',
     onPress: () => ({}),
-  }
+  };
 }

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ class NavigationBar extends Component {
       PropTypes.shape(TitleShape),
       PropTypes.element,
     ]),
-  }
+  };
 
   static defaultProps = {
     statusBar: {
@@ -122,6 +122,6 @@ class NavigationBar extends Component {
     title: {
       title: '',
     },
-  }
+  };
 }
 module.exports = NavigationBar;


### PR DESCRIPTION
First of all thanks for making this module!

My application won't compile because semicolons were missing. It was working yesterday though. I'm thinking it could be related to https://github.com/babel/babel/pull/3225