### PR TITLE
StatusBarIOS is deprecated, change to StatusBar

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import React from 'react-native';
 const {
   PixelRatio,
-  StatusBarIOS,
+  StatusBar,
   Component,
   Text,
   View,
@@ -33,13 +33,13 @@ const StatusBarShape = {
 function customizeStatusBar(data) {
   if (Platform.OS === 'ios') {
     if (data.style) {
-      StatusBarIOS.setStyle(data.style, true);
+      StatusBar.setBarStyle(data.style, true);
     }
     const animation = data.hidden ?
     (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
     (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);
 
-    StatusBarIOS.setHidden(data.hidden, animation);
+    StatusBar.setHidden(data.hidden, animation);
   }
 }
 


### PR DESCRIPTION
Hi, `StatusBarIOS` is deprecated. [They are recommend](https://facebook.github.io/react-native/releases/next/docs/statusbarios.html) to use `StatusBar` instead. 