### PR TITLE
Use flex box style to make buttons and title align center in vertical…

### DIFF
--- a/NavbarButton.js
+++ b/NavbarButton.js
@@ -13,7 +13,7 @@ export default class NavbarButton extends Component {
     const { style, tintColor, margin, title, handler } = this.props;
 
     return (
-      <TouchableOpacity onPress={handler}>
+      <TouchableOpacity style={styles.navBarButton} onPress={handler}>
         <View style={style}>
           <Text style={[styles.navBarButtonText, { color: tintColor, }, ]}>{title}</Text>
         </View>

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class NavigationBar extends Component {
 
   getButtonElement(data = {}, style) {
     return (
-      <View style={styles.navBarButton}>
+      <View style={styles.navBarButtonContainer}>
         {(!!data.props) ? data : (
           <NavbarButton
             title={data.title}

--- a/index.js
+++ b/index.js
@@ -54,15 +54,17 @@ class NavigationBar extends Component {
   }
 
   getButtonElement(data = {}, style) {
-    if (!!data.props) {
-      return <View style={styles.navBarButton}>{data}</View>;
-    }
-
-    return <NavbarButton
-      title={data.title}
-      style={[data.style, style, ]}
-      tintColor={data.tintColor}
-      handler={data.handler} />;
+    return (
+      <View style={styles.navBarButton}>
+        {(!!data.props) ? data : (
+          <NavbarButton
+            title={data.title}
+            style={[data.style, style, ]}
+            tintColor={data.tintColor}
+            handler={data.handler}/>
+        )}
+      </View>
+    );
   }
 
   getTitleElement(data) {
@@ -73,10 +75,12 @@ class NavigationBar extends Component {
     const colorStyle = data.tintColor ? { color: data.tintColor, } : null;
 
     return (
-      <Text
-        style={[styles.navBarTitleText, colorStyle, ]}>
-        {data.title}
-      </Text>
+      <View style={styles.navBarTitleContainer}>
+        <Text
+          style={[styles.navBarTitleText, colorStyle, ]}>
+          {data.title}
+        </Text>
+      </View>
     );
   }
 

--- a/styles.js
+++ b/styles.js
@@ -22,7 +22,13 @@ module.exports = {
     bottom: 7,
     alignItems: 'center',
   },
+  navBarButtonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'stretch',
+  },
   navBarButton: {
+    flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/styles.js
+++ b/styles.js
@@ -13,6 +13,7 @@ module.exports = {
     height: NAV_BAR_HEIGHT,
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'stretch',
   },
   customTitle: {
     position: 'absolute',
@@ -22,22 +23,26 @@ module.exports = {
     alignItems: 'center',
   },
   navBarButton: {
-    marginTop: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   navBarButtonText: {
     fontSize: 17,
     letterSpacing: 0.5,
-    marginTop: 12,
+  },
+  navBarTitleContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   navBarTitleText: {
     fontSize: 17,
     letterSpacing: 0.5,
     color: '#333',
     fontWeight: '500',
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    bottom: 7,
-    textAlign: 'center',
   },
 };


### PR DESCRIPTION
I found that the title text of navigation bar is not center aligned in vertical, after reviewing the code, I made some change:

use flex box style to make buttons and title align center in vertical instead of using fixed margin or padding. 

the buttons and title will be center aligned regardless font family / font size or language/locale. 

@Kureev Please review this commit and give me feedback, thank you!