### PR TITLE
Fixed imperative API

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const StatusBarShape = {
 function customizeStatusBar(data) {
   if (Platform.OS === 'ios') {
     if (data.style) {
-      StatusBar.barStyle = data.style;
+      StatusBar.setBarStyle(data.style);
     }
     const animation = data.hidden ?
     (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :


### PR DESCRIPTION
In my case, with react-native 0.22, `StatusBar.barStyle = data.style` won't work as expected. But `setBarStyle` did work.