### PR TITLE
Adds `statusBar.animated` and fixes animation bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,21 +26,26 @@ const StatusBarShape = {
   style: PropTypes.oneOf(['light-content', 'default', ]),
   hidden: PropTypes.bool,
   tintColor: PropTypes.string,
+  animated: PropTypes.bool, // affects `style` and `hidden`
   hideAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ]),
   showAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ])
 };
 
 function customizeStatusBar(data) {
   if (Platform.OS === 'ios') {
+    const animated = (data.animated || NavigationBar.defaultProps.statusBar.animated)
     if (data.style) {
-      StatusBar.setBarStyle(data.style);
+      StatusBar.setBarStyle(data.style, animated);
     }
-    const animation = data.hidden ?
-    (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
-    (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);
-
-    StatusBar.showHideTransition = animation;
-    StatusBar.hidden = data.hidden;
+    if (data.hidden !== undefined) {
+      let showHideTransition = 'none';
+      if (animated) {
+        showHideTransition = data.hidden ?
+          (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
+          (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);
+      }
+      StatusBar.setHidden(data.hidden, showHideTransition);
+    }
   }
 }
 
@@ -131,6 +136,7 @@ class NavigationBar extends Component {
     statusBar: {
       style: 'default',
       hidden: false,
+      animated: false,
       hideAnimation: 'slide',
       showAnimation: 'slide',
     },


### PR DESCRIPTION
The new `animated` property of the `statusBar` prop object affects
both `style` and `hidden` when they are changed. Fixes bugs so the
animations play. (They have to be passed in the StatusBar calls.)

There are several other changes I wanted to make in this PR but resisted doing so to avoid breaking changes for existing users of the component. So take these as additional feature requests... 1) now that the StatusBar API has changed, it would be nice to make prop names of `statusBar` match the official API, and 2) Android should now be supported and the API includes `backgroundColor` support for android.