### PR TITLE
Statusbar lazy update

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,12 @@ class NavigationBar extends Component {
   }
 
   componentWillReceiveProps(props) {
-    customizeStatusBar(this.props.statusBar);
+    if (props.statusBar
+        && ((props.statusBar.hidden !== this.props.statusBar.hidden)
+            || (props.statusBar.style !== this.props.statusBar.style)
+            || (props.statusBar.tintColor !== this.props.statusBar.tintColor))) {
+      customizeStatusBar(this.props.statusBar);
+    }
   }
 
   getButtonElement(data = {}, style) {

--- a/index.js
+++ b/index.js
@@ -26,21 +26,26 @@ const StatusBarShape = {
   style: PropTypes.oneOf(['light-content', 'default', ]),
   hidden: PropTypes.bool,
   tintColor: PropTypes.string,
+  animated: PropTypes.bool, // affects `style` and `hidden`
   hideAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ]),
   showAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ])
 };
 
 function customizeStatusBar(data) {
   if (Platform.OS === 'ios') {
+    const animated = (data.animated || NavigationBar.defaultProps.statusBar.animated)
     if (data.style) {
-      StatusBar.setBarStyle(data.style);
+      StatusBar.setBarStyle(data.style, animated);
     }
-    const animation = data.hidden ?
-    (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
-    (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);
-
-    StatusBar.showHideTransition = animation;
-    StatusBar.hidden = data.hidden;
+    if (data.hidden !== undefined) {
+      let showHideTransition = 'none';
+      if (animated) {
+        showHideTransition = data.hidden ?
+          (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
+          (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);
+      }
+      StatusBar.setHidden(data.hidden, showHideTransition);
+    }
   }
 }
 
@@ -131,6 +136,7 @@ class NavigationBar extends Component {
     statusBar: {
       style: 'default',
       hidden: false,
+      animated: false,
       hideAnimation: 'slide',
       showAnimation: 'slide',
     },


### PR DESCRIPTION
The StatusBar should not be updated every time a prop changes, it
should be updated when one of the visual props changes: `style`,
`hidden` or `tintColor`.

The current aggressive update strategy causes problems in apps with
multiple nav bars, since bars on views hidden lower in the route stack
can end up operating on the status bar, which is obviously unwanted
behavior.