### PR TITLE
Lazy-update status bar

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,12 @@ class NavigationBar extends Component {
   }
 
   componentWillReceiveProps(props) {
-    customizeStatusBar(this.props.statusBar);
+    if (props.statusBar
+        && ((props.statusBar.hidden !== this.props.statusBar.hidden)
+            || (props.statusBar.style !== this.props.statusBar.style)
+            || (props.statusBar.tintColor !== this.props.statusBar.tintColor))) {
+      customizeStatusBar(this.props.statusBar);
+    }
   }
 
   getButtonElement(data = {}, style) {


### PR DESCRIPTION
The StatusBar should not be updated every time a prop changes, it
should be updated when one of the visual props changes: `style`,
`hidden` or `tintColor`.

The current aggressive update strategy causes problems in apps with
multiple nav bars, since bars on views hidden lower in the route stack
can end up operating on the status bar, which is obviously unwanted
behavior.